### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy<2.0.0
 setproctitle
 opencv-python
+picamera2
 git+https://github.com/hailo-ai/hailo-apps-infra.git


### PR DESCRIPTION
Added requirements for PiOSlite. As of September 2022, Picamera2 is pre-installed on Raspberry Pi OS images, but not on Raspberry Pi OS Lite images.

https://github.com/raspberrypi/picamera2