### PR TITLE
Makes the detection application use the new Hailo Apps Infra RTP Pipeline

### DIFF
--- a/basic_pipelines/detection.py
+++ b/basic_pipelines/detection.py
@@ -11,7 +11,7 @@ from hailo_apps_infra.hailo_rpi_common import (
     get_numpy_from_buffer,
     app_callback_class,
 )
-from hailo_apps_infra.detection_pipeline import GStreamerDetectionApp
+from hailo_apps_infra.detection_rtp_pipeline import GStreamerDetectionApp
 
 # -----------------------------------------------------------------------------------------------
 # User-defined class to be used in the callback function
@@ -39,7 +39,8 @@ def app_callback(pad, info, user_data):
 
     # Using the user_data to count the number of frames
     user_data.increment()
-    string_to_print = f"Frame count: {user_data.get_count()}\n"
+    frame_count = user_data.get_count()
+    string_to_print = f"Frame count: {frame_count}\n"
 
     # Get the caps from the pad
     format, width, height = get_caps_from_pad(pad)
@@ -79,7 +80,8 @@ def app_callback(pad, info, user_data):
         frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
         user_data.set_frame(frame)
 
-    print(string_to_print)
+    if frame_count % 100 == 0:
+        print(string_to_print)
     return Gst.PadProbeReturn.OK
 
 if __name__ == "__main__":

--- a/basic_pipelines/rstp_server.py
+++ b/basic_pipelines/rstp_server.py
@@ -1,0 +1,34 @@
+import gi
+gi.require_version('Gst', '1.0')
+gi.require_version('GstRtspServer', '1.0')
+
+from gi.repository import Gst, GstRtspServer, GLib
+
+Gst.init(None)
+
+class UdpToRtspFactory(GstRtspServer.RTSPMediaFactory):
+    def __init__(self):
+        super(UdpToRtspFactory, self).__init__()
+        self.set_shared(True)
+
+    def do_create_element(self, url):
+        pipeline_str = (
+            'udpsrc port=5000 caps="application/x-rtp,media=video,encoding-name=H264,payload=96" ! '
+            'rtph264depay ! rtph264pay config-interval=1 name=pay0 pt=96'
+        )
+        return Gst.parse_launch(f"( {pipeline_str} )")
+
+class UdpRtspServer:
+    def __init__(self):
+        self.server = GstRtspServer.RTSPServer()
+        factory = UdpToRtspFactory()
+        mount_points = self.server.get_mount_points()
+        mount_points.add_factory("/stream", factory)
+        self.server.attach(None)
+
+if __name__ == "__main__":
+    print("RTSP server streaming from UDP at rtsp://<ip>:8554/stream")
+    server = UdpRtspServer()
+    loop = GLib.MainLoop()
+    loop.run()
+


### PR DESCRIPTION
This PR also adds a simple RSTP server to be used along with the detection application. After running the detection application, just start the server with `python basic_pipelines/rstp_server.py`.

To watch the stream from a McBook, use FFPlay:

```
ffplay -fflags nobuffer -flags low_delay -rtsp_transport tcp rtsp://your_rpi_ip:8554/stream
```